### PR TITLE
Update TreeDefinition to add skaterNumber

### DIFF
--- a/Sources/StatterBook/Time.swift
+++ b/Sources/StatterBook/Time.swift
@@ -41,7 +41,7 @@ public extension Game {
         for periodNum in 1 ... 2 {
             let period = self.period(periodNum)
             if let time = period.walltimeStart {
-                retval.append(.init(time: time, event: .periodEnd(period)))
+                retval.append(.init(time: time, event: .periodStart(period)))
             }
             if let time = period.walltimeEnd {
                 retval.append(.init(time: time, event: .periodEnd(period)))

--- a/Sources/StatterCRG/TreeDefinition
+++ b/Sources/StatterCRG/TreeDefinition
@@ -338,6 +338,7 @@ node Fielding <Jam TeamJam> {
     let Readonly : Bool
     var SitFor3 : Bool
     var Skater : UUID
+    var skaterNumber : String
 }
 
 node ScoringTrip  <Jam TeamJam> {


### PR DESCRIPTION
Add in the member skaterNumber which was added to the Fieldings object in the v4.0.0 CRG so as to have it immediately available instead of using Skater UUID and looking that up.